### PR TITLE
FIXED bug in C method for DecisionTree classifiers

### DIFF
--- a/sklearn_porter/classifier/DecisionTreeClassifier/templates/c/method.txt
+++ b/sklearn_porter/classifier/DecisionTreeClassifier/templates/c/method.txt
@@ -1,4 +1,4 @@
-int {method_name}(float atts[{n_classes}]) {{
+int {method_name}(float atts[{n_features}]) {{
 
     int classes[{n_classes}];
     {branches}


### PR DESCRIPTION
The DecisionTree method was using the number of classes instead of number of features for the size of the input parameter of the predict function.

This situation might provoke a SIGSEGV