### PR TITLE
FIXED bug in the implem. of AdaBoostClassifier

### DIFF
--- a/sklearn_porter/classifier/AdaBoostClassifier/__init__.py
+++ b/sklearn_porter/classifier/AdaBoostClassifier/__init__.py
@@ -210,8 +210,9 @@ class AdaBoostClassifier(Classifier):
             model.tree_.threshold, model.tree_.value,
             feature_indices, 0, 1)
 
+        suffix = "{0:0" + str(len(str(self.n_estimators))) + "d}"
         return self.temp('single_method').format(
-            str(model_index), self.method_name,
+            suffix.format(model_index), self.method_name,
             self.n_classes, tree_branches)
 
     def create_method(self):


### PR DESCRIPTION
Functions predict_* were named predict_1, predict_2, ..., predict_9, but when they were called the format was the following _01, _02, ... _09. This patch unifies the naming structure.
I don't understand why the developer wished to name them _01 and not directly _1.