### PR TITLE
Reusing instances of MLPClassifier / MLPRegressor

### DIFF
--- a/sklearn_porter/estimator/classifier/MLPClassifier/templates/java/exported.class.txt
+++ b/sklearn_porter/estimator/classifier/MLPClassifier/templates/java/exported.class.txt
@@ -76,10 +76,10 @@ class {class_name} {{
 
         for (int i = 0; i < this.clf.network.length - 1; i++) {{
             for (int j = 0; j < this.clf.network[i + 1].length; j++) {{
+                this.clf.network[i + 1][j] = this.clf.bias[i][j];
                 for (int l = 0; l < this.clf.network[i].length; l++) {{
                     this.clf.network[i + 1][j] += this.clf.network[i][l] * this.clf.weights[i][l][j];
                 }}
-                this.clf.network[i + 1][j] += this.clf.bias[i][j];
             }}
             if ((i + 1) < (this.clf.network.length - 1)) {{
                 this.clf.network[i + 1] = this.compute(this.clf.hidden, this.clf.network[i + 1]);

--- a/sklearn_porter/estimator/classifier/MLPClassifier/templates/java/separated.class.txt
+++ b/sklearn_porter/estimator/classifier/MLPClassifier/templates/java/separated.class.txt
@@ -67,10 +67,10 @@ class {class_name} {{
 
         for (int i = 0; i < this.network.length - 1; i++) {{
             for (int j = 0; j < this.network[i + 1].length; j++) {{
+                this.network[i + 1][j] = this.bias[i][j];
                 for (int l = 0; l < this.network[i].length; l++) {{
                     this.network[i + 1][j] += this.network[i][l] * this.weights[i][l][j];
                 }}
-                this.network[i + 1][j] += this.bias[i][j];
             }}
             if ((i + 1) < (this.network.length - 1)) {{
                 this.network[i + 1] = this.compute(this.hidden, this.network[i + 1]);

--- a/sklearn_porter/estimator/classifier/MLPClassifier/templates/js/exported.class.txt
+++ b/sklearn_porter/estimator/classifier/MLPClassifier/templates/js/exported.class.txt
@@ -88,10 +88,10 @@ var {class_name} = function(jsonFile) {{
                 this.mdl.network[0] = neurons;
                 for (var i = 0; i < this.mdl.network.length - 1; i++) {{
                     for (var j = 0; j < this.mdl.network[i + 1].length; j++) {{
+                        this.mdl.network[i + 1][j] = this.mdl.bias[i][j];
                         for (var l = 0; l < this.mdl.network[i].length; l++) {{
                             this.mdl.network[i + 1][j] += this.mdl.network[i][l] * this.mdl.weights[i][l][j];
                         }}
-                        this.mdl.network[i + 1][j] += this.mdl.bias[i][j];
                     }}
                     if ((i + 1) < (this.mdl.network.length - 1)) {{
                         this.mdl.network[i + 1] = compute(this.mdl.hidden_activation, this.mdl.network[i + 1]);

--- a/sklearn_porter/estimator/classifier/MLPClassifier/templates/js/separated.class.txt
+++ b/sklearn_porter/estimator/classifier/MLPClassifier/templates/js/separated.class.txt
@@ -53,10 +53,10 @@ var {class_name} = function(hidden, output, layers, weights, bias) {{
 
         for (var i = 0; i < this.network.length - 1; i++) {{
             for (var j = 0; j < this.network[i + 1].length; j++) {{
+                this.network[i + 1][j] = this.bias[i][j];
                 for (var l = 0; l < this.network[i].length; l++) {{
                     this.network[i + 1][j] += this.network[i][l] * this.weights[i][l][j];
                 }}
-                this.network[i + 1][j] += this.bias[i][j];
             }}
             if ((i + 1) < (this.network.length - 1)) {{
                 this.network[i + 1] = compute(this.hidden, this.network[i + 1]);

--- a/sklearn_porter/estimator/regressor/MLPRegressor/templates/js/method.txt
+++ b/sklearn_porter/estimator/regressor/MLPRegressor/templates/js/method.txt
@@ -3,10 +3,10 @@ this.{method_name} = function(neurons) {{
 
     for (var i = 0; i < this.network.length - 1; i++) {{
         for (var j = 0; j < this.network[i + 1].length; j++) {{
+            this.network[i + 1][j] = this.bias[i][j];
             for (var l = 0; l < this.network[i].length; l++) {{
                 this.network[i + 1][j] += this.network[i][l] * this.weights[i][l][j];
             }}
-            this.network[i + 1][j] += this.bias[i][j];
         }}
         if ((i + 1) < (this.network.length - 1)) {{
             this.network[i + 1] = compute(this.hidden, this.network[i + 1], this.network.length);


### PR DESCRIPTION
Since I had to do more than one classification job at a time I was looking for a way to reuse the the instantiated classes. When wiping  `double[] network` both can simply be reused.

The additions being commutative, I decided to put the bias addition in front of the inner for-loop as a sort of initialization.

Note: This pull request doesn't change the behavior on standalone executions, but enables reusing instances when using the transpiled source files in other projects.