### PR TITLE
Fix for C RandomForestClassifier code generation

### DIFF
--- a/sklearn_porter/estimator/classifier/RandomForestClassifier/__init__.py
+++ b/sklearn_porter/estimator/classifier/RandomForestClassifier/__init__.py
@@ -275,7 +275,7 @@ class RandomForestClassifier(Classifier):
         :return : string
             The created method.
         """
-        indices = [self.repr(e) for e in estimator.tree_.feature]
+        indices = [str(e) for e in estimator.tree_.feature]
 
         tree_branches = self.create_branches(
             estimator.tree_.children_left, estimator.tree_.children_right,


### PR DESCRIPTION
Don't apply num_format conversion in RandomForestClassifier code generation for feature indices.¨

See #40 