### PR TITLE
Fix the argument name in generated method name

### DIFF
--- a/sklearn_porter/estimator/classifier/DecisionTreeClassifier/templates/ruby/embedded.method.txt
+++ b/sklearn_porter/estimator/classifier/DecisionTreeClassifier/templates/ruby/embedded.method.txt
@@ -1,4 +1,4 @@
-def self.{method_name} (atts)
+def self.{method_name} (features)
 	classes = Array.new({n_classes}, 0)
 	{branches}
 


### PR DESCRIPTION
At the moment, the generated method's argument is called `atts`, while in the body of the method it references to as `features`. This is mirroring change to the working version of a [Ruby's "Separated" Classifier](https://github.com/nok/sklearn-porter/blob/stable/sklearn_porter/estimator/classifier/DecisionTreeClassifier/templates/ruby/separated.class.txt#L19)