### PR TITLE
FIX: SVC's gamma = 'scale' representation

### DIFF
--- a/sklearn_porter/estimator/classifier/SVC/__init__.py
+++ b/sklearn_porter/estimator/classifier/SVC/__init__.py
@@ -182,6 +182,8 @@ class SVC(Classifier):
         self.gamma = self.params['gamma']
         if self.gamma == 'auto':
             self.gamma = 1. / self.n_features
+        elif self.gamma == 'scale':
+            self.gamma = est._gamma  # computed value of 1 / (n_features * X.var())
         self.gamma = self.repr(self.gamma)
 
         # Coefficient and degree:


### PR DESCRIPTION
If gamma is 'scale', use the computed value stored on the estimator object, rather than repr of the string `'scale'`.

reference: https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/svm/_base.py#L206-L210