### PR TITLE
Include jinja2 templates in package manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 include requirements.txt readme.md changelog.md LICENSE
-recursive-include sklearn_porter *.py *.txt *.json
+recursive-include sklearn_porter *.py *.txt *.json *.jinja2


### PR DESCRIPTION
I was having difficulties with some of the template combinations and realized that the `.jinja2` files were not being included in the package. This change fixes the examples on my machine when running with a pip installed `porter` cli